### PR TITLE
Problem when a replacement token is 0

### DIFF
--- a/lib/prepare-request.js
+++ b/lib/prepare-request.js
@@ -10,7 +10,7 @@ module.exports = function (method, path) {
 
       if (isOptional) {
         // Optional
-        if (!restArgs[i]) {
+        if (restArgs[i] == undefined) {
           replaced++
           path = path.replace('/' + token, '')
           return
@@ -19,7 +19,7 @@ module.exports = function (method, path) {
 
       replaced++
 
-      if (restArgs[i]) {
+      if (restArgs[i] !== undefined) {
         path = path.replace(token, restArgs[i])
       }
     })

--- a/lib/prepare-request.js
+++ b/lib/prepare-request.js
@@ -10,7 +10,7 @@ module.exports = function (method, path) {
 
       if (isOptional) {
         // Optional
-        if (restArgs[i] == undefined) {
+        if (restArgs[i] === undefined) {
           replaced++
           path = path.replace('/' + token, '')
           return

--- a/test/prepare-request.test.js
+++ b/test/prepare-request.test.js
@@ -25,4 +25,10 @@ describe('Prepare Request', function () {
       e.message.should.equal('Unreplaced tokens')
     }
   })
+
+  it('should accept falsy tokens', function () {
+    var preparedReq = prepareRequest('GET', 'hello/{foo}/world', 0);
+
+    preparedReq.url.should.equal('hello/0/world');
+  })
 })


### PR DESCRIPTION
The conditional "if (restArgs[i]) {...}" in lib/prepare-request.js fails when the token replacement argument is 0.

I have changed it to check if restArgs[i] is undefined, and also in the lines above when checking an optional argument doesn't exist.

Thanks,
Richard Ayres

(PS not sure if you're watching or maintaining this, but I thought it best to push fixes upstream)